### PR TITLE
Update download link to latest release

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -5,7 +5,7 @@ If you use CommandPost for paid/commercial work, we'd LOVE you to sponsor our co
 You can learn more [here](/sponsor).
 !!!
 
-You can download the latest **CommandPost v1.4.18** release [here](https://github.com/CommandPost/CommandPost/releases/download/1.4.18/CommandPost_1.4.18.dmg){target="_blank"}.
+You can download the latest **CommandPost v1.4.20** release [here](https://github.com/CommandPost/CommandPost/releases/download/1.4.20/CommandPost_1.4.20.dmg){target="_blank"}.
 
 You can find all previous versions of CommandPost on [GitHub](https://github.com/CommandPost/CommandPost/releases/){target="_blank"}.
 


### PR DESCRIPTION
Hi, I just downloaded CommandPost and noticed that I had an update to do. This PR updates the download link to the latest version on the [releases page](https://github.com/CommandPost/CommandPost/releases/). 